### PR TITLE
:arrow_up: :lock: Upgrade debug package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-preset-stage-2": "6.24.1",
     "babel-register": "6.26.0",
     "chai": "4.1.2",
+    "debug": "3.1.0",
     "eslint": "4.9.0",
     "eslint-plugin-ante": "1.0.0",
     "jsdoc": "3.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,7 +1205,7 @@ debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@3.1.0:
+debug@3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:


### PR DESCRIPTION
Fixes [#5](https://github.com/twuni/ante-boilerplate-js/issues/5).

The **nyc** package has a transitive dependency on **debug@2.6.8**,
which we discovered via Snyk has a low-severity ReDoS security
vulnerability. This commit attempts to override this dependency
with a newer version in order to provide a short-term patch until
the **nyc** package is updated to no longer include this vulnerability.