### PR TITLE
:no_entry_sign: Remove Greenkeeper badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Ante Boilerplate for JavaScript Projects
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/twuni/ante-boilerplate-js.svg)](https://greenkeeper.io/)
-
 [![CircleCI](https://circleci.com/gh/twuni/ante-boilerplate-js.svg?style=svg)](https://circleci.com/gh/twuni/ante-boilerplate-js)
 
 This project simply provides the boilerplate for your JavaScript project to support the essential quality tools, including:


### PR DESCRIPTION
Greenkeeper has been removed for a few reasons:

 1. Greenkeeper does not sign commits, so it does not play nicely with the GPG application for enforcing signed commits on pull requests.
 2. Greenkeeper does not work with Yarn lockfiles, unless the CI build is given push access to the repository, which is an unacceptable permission to grant due to security concerns and the possibility of infinitely looping commit/build cycles.
 3. Greenkeeper does not format commits consistently with the repository's conventions.
 4. Greenkeeper creates pull requests off of the main repo instead of a fork. This pollutes the main repo and shirks GitHub Flow convention.

While Greenkeeper does provide some benefits, these deficiencies are an unacceptable trade-off for production use.

For posterity, the benefits provided by Greenkeeper include:

 1. Notification of dependency updates (via pull request).
 2. Integration testing of dependency updates (since a pull request triggers a CI build).
 3. Documented context of dependency updates (via commit history and release notes, if available, in the pull request).

If these benefits can be achieved without the deficiencies listed above, then :heart: :heart: :heart:.