### PR TITLE
:arrow_up: Upgrade CircleCI base image to twuni/javascript:1.0.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~
   docker:
-  - image: twuni/javascript:1.0.6
+  - image: twuni/javascript:1.0.7
 
 version: 2
 jobs:


### PR DESCRIPTION
twuni/javascript:1.0.7 [source](https://github.com/twuni/docker-images/tree/master/twuni/javascript/1.0.7)